### PR TITLE
Capability to yield to promises.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 export { execute } from './execute';
 export { timeout } from './timeout';
 export { call } from './execution';
+export { promiseOf } from './promise-of';

--- a/src/promise-of.js
+++ b/src/promise-of.js
@@ -1,0 +1,18 @@
+/**
+ * An execution controller that resumes or throws based
+ * on a promise.
+ */
+export function promiseOf(promise) {
+  return function control(execution) {
+
+    let succeed = value => execution.resume(value);
+    let fail = err => execution.throw(err);
+    let noop = x => x;
+
+    promise.then(value => succeed(value)).catch(error => fail(error));
+
+    // this execution has passed out of scope, so we don't care
+    // what happened to the promise, so make the callbacks noops.
+    return () => succeed = fail = noop;
+  };
+}

--- a/tests/promise-of.test.js
+++ b/tests/promise-of.test.js
@@ -1,0 +1,78 @@
+import expect from 'expect';
+
+import { promiseOf, execute } from '../src/index';
+
+describe('promise-of yielding on a promise', () => {
+  let execution, deferred, error;
+
+  beforeEach(() => {
+    error = undefined;
+    deferred = new Deferred();
+    execution = execute(function*() {
+      try {
+        return yield promiseOf(deferred.promise);
+      } catch (e) {
+        error = e;
+      }
+    });
+  });
+
+  describe('when the promise resolves', () => {
+    beforeEach(() => {
+      return deferred.resolve('hello');
+    });
+
+    it('completes the execution with the result', () => {
+      expect(execution.isCompleted).toEqual(true);
+      expect(execution.result).toEqual('hello');
+    });
+  });
+
+  describe('when the promise rejects', () => {
+    let boom;
+    beforeEach(() => {
+      boom = new Error('boom!');
+      return deferred.reject(boom).catch(() => {});
+    });
+
+    it('errors out the execution', () => {
+      expect(error).toEqual(boom);
+    });
+  });
+
+  describe('when the promise resolves after halting execution', () => {
+    beforeEach(() => {
+      execution.halt();
+      return deferred.resolve('hi');
+    });
+
+    it('is no problem', () => {
+      expect(execution.isHalted).toEqual(true);
+    });
+  });
+
+  describe('when the promise rejects after halting execution', () => {
+    beforeEach(() => {
+      execution.halt();
+      return deferred.reject(new Error('boom!')).catch(() => {});
+    });
+
+    it('is no problem', () => {
+      expect(execution.isHalted).toEqual(true);
+      expect(error).toBeUndefined();
+    });
+  });
+});
+
+function Deferred() {
+  this.promise = new Promise((resolve, reject) => {
+    this.resolve = value => {
+      resolve(value);
+      return this.promise;
+    };
+    this.reject = error => {
+      reject(error);
+      return this.promise;
+    };
+  });
+}


### PR DESCRIPTION
Structured concurrency lets you manage asynchronous process and tear them down and set them up as transactional units. However, the primary mechanism for most async apis is the promise. We need a way to be able to easily yield an async execution until the promise either completes, or raise an error when it rejects.

This adapts the promise api using an execution controller named `promiseOf` which resumes an execution when the promise resolves and throws an error inside the execution when the promise rejects. Using this basic primitive, we can adapt most apis to an async execution.