### PR TITLE
Implicitly treat promises as an execution step.

### DIFF
--- a/src/execution.js
+++ b/src/execution.js
@@ -1,3 +1,4 @@
+import { promiseOf } from './promise-of';
 import { isGeneratorFunction, toGeneratorFunction } from './generator-function';
 import Continuation from './continuation';
 
@@ -237,8 +238,10 @@ function controllerFor(value) {
     return value;
   } else if (value == null) {
     return x => x;
+  } else if (typeof value.then === 'function' && typeof value.catch === 'function') {
+    return promiseOf(value);
   } else {
-    throw new Error('generators should yield either another generator or control function, not `${value}`');
+    throw new Error(`generators should yield either another generator or control function, not '${value}'`);
   }
 }
 

--- a/tests/promise-of.test.js
+++ b/tests/promise-of.test.js
@@ -1,8 +1,8 @@
 import expect from 'expect';
 
-import { promiseOf, execute } from '../src/index';
+import { execute } from '../src/index';
 
-describe('promise-of yielding on a promise', () => {
+describe('yielding on a promise', () => {
   let execution, deferred, error;
 
   beforeEach(() => {
@@ -10,7 +10,7 @@ describe('promise-of yielding on a promise', () => {
     deferred = new Deferred();
     execution = execute(function*() {
       try {
-        return yield promiseOf(deferred.promise);
+        return yield deferred.promise;
       } catch (e) {
         error = e;
       }


### PR DESCRIPTION
The most common form of managing asynchrony in JavaScript is the promise. That's why we included the `promiseOf` helper to [adapt a promise into an execution context][1].

However, after using the api to build something, it became immediately apparent that the most intuitive thing was to be able to yield to any promise, and that it was pretty much busy work to have to wrap a promise in a call to `promise-of` yourself.

This change makes wrapping in `promise-of` implicit. in other words, if you yield to a promise, it will automatically create a promise-of execution controller to resume evaluation once the promise has settled.

For example:

```js
function getJSON(url, init) {
  return function*() {
    let response = yield promiseOf(fetch(url, init));
    return yield promiseOf(response.json());
  }
}
```

becomes:

```js
function getJSON(url, init) {
  return function*() {
    let response = yield fetch(url, init);
    return yield response.json();
  }
}
```

[1]: https://github.com/cowboyd/effection.js/pull/4